### PR TITLE
Implement candle ingestion node

### DIFF
--- a/backend/graph/nodes/ingestion.py
+++ b/backend/graph/nodes/ingestion.py
@@ -3,11 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Iterable, List
+
+import ccxt.async_support as ccxt
+
+PAIRS = ["BTC/USDT", "ETH/USDT", "SOL/USDT", "BNB/USDT", "DOGE/USDT"]
 
 
 @dataclass
 class Candle:
-    ts: str
+    """Represents a single 1-minute candle."""
+
+    ts: datetime
     pair: str
     open: float
     high: float
@@ -16,6 +24,27 @@ class Candle:
     volume: float
 
 
-async def fetch_candles() -> list[Candle]:
-    """Placeholder for candle fetch logic."""
-    return []
+async def fetch_candles(pairs: Iterable[str]) -> List[Candle]:
+    """Fetch the latest 1-minute candle for each pair using ccxt."""
+    exchange = ccxt.binance()
+    candles: List[Candle] = []
+    try:
+        for pair in pairs:
+            data = await exchange.fetch_ohlcv(pair, timeframe="1m", limit=1)
+            if not data:
+                continue
+            ts, open_, high, low, close, volume = data[-1]
+            candles.append(
+                Candle(
+                    ts=datetime.fromtimestamp(ts / 1000, tz=UTC),
+                    pair=pair,
+                    open=open_,
+                    high=high,
+                    low=low,
+                    close=close,
+                    volume=volume,
+                )
+            )
+    finally:
+        await exchange.close()
+    return candles

--- a/backend/scheduler/loop.py
+++ b/backend/scheduler/loop.py
@@ -1,20 +1,42 @@
 """APScheduler loop for running the research cycle."""
 
 import asyncio
+import logging
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from backend.graph.nodes.ingestion import PAIRS, fetch_candles
+
+logger = logging.getLogger(__name__)
 
 
-async def run_cycle():
-    pass
+async def run_cycle() -> None:
+    """Fetch candles for all pairs and log the results."""
+    candles = await fetch_candles(PAIRS)
+    for candle in candles:
+        logger.info(
+            "%s %s o=%s h=%s l=%s c=%s v=%s",
+            candle.ts.isoformat(),
+            candle.pair,
+            candle.open,
+            candle.high,
+            candle.low,
+            candle.close,
+            candle.volume,
+        )
 
 
-async def check_hits():
-    pass
+async def check_hits() -> None:
+    """Evaluate unresolved signals (placeholder)."""
+    return None
 
 
-def start():
+def start() -> None:
+    """Start the APScheduler event loop."""
     scheduler = AsyncIOScheduler()
     scheduler.add_job(run_cycle, "cron", second=0)
     scheduler.add_job(check_hits, "cron", second=10)
     scheduler.start()
-    asyncio.get_event_loop().run_forever()
+    try:
+        asyncio.get_event_loop().run_forever()
+    except KeyboardInterrupt:
+        scheduler.shutdown()

--- a/backend/tests/test_ingestion.py
+++ b/backend/tests/test_ingestion.py
@@ -1,0 +1,26 @@
+import datetime
+
+import pytest
+from backend.graph.nodes.ingestion import fetch_candles
+
+
+@pytest.mark.asyncio
+async def test_fetch_candles(monkeypatch):
+    class DummyExchange:
+        async def fetch_ohlcv(self, pair, timeframe="1m", limit=1):
+            return [[1718138400000, 1.0, 2.0, 3.0, 4.0, 5.0]]
+        async def close(self):
+            pass
+    monkeypatch.setattr(
+        "backend.graph.nodes.ingestion.ccxt.binance", lambda: DummyExchange()
+    )
+    candles = await fetch_candles(["BTC/USDT"])
+    assert len(candles) == 1
+    c = candles[0]
+    assert isinstance(c.ts, datetime.datetime)
+    assert c.pair == "BTC/USDT"
+    assert c.open == 1.0
+    assert c.high == 2.0
+    assert c.low == 3.0
+    assert c.close == 4.0
+    assert c.volume == 5.0


### PR DESCRIPTION
## Summary
- implement `fetch_candles` using `ccxt` for Binance pairs
- log new candles each minute in APScheduler loop
- add unit test for candle ingestion

## Testing
- `pytest backend/tests/test_ingestion.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8f0790a88320a37aed1bb30b7cca