### PR TITLE
Add persistence and signal evaluation

### DIFF
--- a/backend/db/persistence.py
+++ b/backend/db/persistence.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import pandas as pd
+
+from backend.graph.nodes.ingestion import Candle as CandleDTO
+from backend.graph.nodes.llm_scoring import SignalCandidate
+from .models import Candle, Indicator, Signal
+from .session import session_scope
+
+
+async def save_candles(candles: Iterable[CandleDTO]) -> None:
+    """Persist candles fetched from the exchange."""
+    records: List[Candle] = [
+        Candle(
+            ts=c.ts,
+            pair=c.pair,
+            open=c.open,
+            high=c.high,
+            low=c.low,
+            close=c.close,
+            volume=c.volume,
+        )
+        for c in candles
+    ]
+    async with session_scope() as session:
+        session.add_all(records)
+
+
+async def save_indicators(df: pd.DataFrame) -> None:
+    """Persist computed indicator rows."""
+    records: List[Indicator] = []
+    for _, row in df.iterrows():
+        records.append(
+            Indicator(
+                ts=row["ts"],
+                pair=row["pair"],
+                ema_fast=row.get("ema_fast"),
+                ema_slow=row.get("ema_slow"),
+                rsi14=row.get("rsi14"),
+                bb_width=row.get("bb_width"),
+                tweet_z=row.get("tweet_z"),
+                news_polarity=row.get("news_polarity"),
+            )
+        )
+    async with session_scope() as session:
+        session.add_all(records)
+
+
+async def save_signals(signals: Iterable[SignalCandidate]) -> None:
+    """Persist generated signals to Timescale."""
+    records = [
+        Signal(
+            id=str(s.id),
+            ts=s.ts,
+            pair=s.pair,
+            direction=s.direction,
+            rationale=s.rationale,
+            confidence=s.confidence,
+        )
+        for s in signals
+    ]
+    async with session_scope() as session:
+        session.add_all(records)

--- a/backend/db/session.py
+++ b/backend/db/session.py
@@ -1,0 +1,20 @@
+import os
+from contextlib import asynccontextmanager
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:secret@localhost:5432/postgres")
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+@asynccontextmanager
+async def session_scope() -> AsyncSession:
+    session = SessionLocal()
+    try:
+        yield session
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+    finally:
+        await session.close()

--- a/backend/graph/nodes/evaluation.py
+++ b/backend/graph/nodes/evaluation.py
@@ -1,6 +1,41 @@
 """Signal hit-rate evaluation node."""
 
+from __future__ import annotations
 
-async def evaluate_signals():
-    """Placeholder for hit-rate logic."""
-    return None
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+
+from backend.db import models
+from backend.db.session import session_scope
+
+
+async def evaluate_signals() -> None:
+    """Mark unresolved signals as hits or misses based on recent candles."""
+    async with session_scope() as session:
+        result = await session.execute(select(models.Signal).where(models.Signal.hit.is_(None)))
+        signals = result.scalars().all()
+        for sig in signals:
+            before_q = (
+                select(models.Candle)
+                .where(models.Candle.pair == sig.pair, models.Candle.ts <= sig.ts)
+                .order_by(models.Candle.ts.desc())
+                .limit(1)
+            )
+            after_q = (
+                select(models.Candle)
+                .where(models.Candle.pair == sig.pair, models.Candle.ts > sig.ts)
+                .order_by(models.Candle.ts.asc())
+                .limit(1)
+            )
+            before = (await session.execute(before_q)).scalar_one_or_none()
+            after = (await session.execute(after_q)).scalar_one_or_none()
+            if not before or not after:
+                continue
+            if sig.direction.lower() == "buy":
+                hit = after.close > before.close
+            else:
+                hit = after.close < before.close
+            sig.hit = hit
+            sig.resolved_at = datetime.now(tz=UTC)
+


### PR DESCRIPTION
## Summary
- create async DB session utilities
- implement Timescale persistence helpers
- add signal hit-rate evaluation node
- expand scheduler to persist data and evaluate signals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb708163c8320b167153df2cef409