### PR TITLE
Integrate trading nodes via LangGraph workflow

### DIFF
--- a/backend/graph/nodes/llm_scoring.py
+++ b/backend/graph/nodes/llm_scoring.py
@@ -9,9 +9,9 @@ from datetime import UTC, datetime
 from typing import List, Sequence
 from uuid import UUID, uuid4
 
+import backend.embeddings.qdrant_client as qc
 import google.generativeai as gen
 import pandas as pd
-from backend.embeddings.qdrant_client import get_client
 from qdrant_client.http import models as qmodels
 
 
@@ -65,7 +65,7 @@ async def score_signals(indicator_batch: pd.DataFrame) -> List[SignalCandidate]:
     except json.JSONDecodeError:
         return []
 
-    client = get_client()
+    client = qc.get_client()
     await _ensure_collection(client)
     results: List[SignalCandidate] = []
     for item in data:

--- a/backend/graph/nodes/social.py
+++ b/backend/graph/nodes/social.py
@@ -22,13 +22,12 @@ class SocialMetrics:
 async def _fetch_tweets(pair: str, session: aiohttp.ClientSession) -> List[str]:
     """Fetch recent tweets mentioning the given pair."""
     token = os.getenv("TWITTER_BEARER_TOKEN", "")
-    if not token:
-        return []
     symbol = pair.split("/")[0]
     url = "https://api.twitter.com/2/tweets/search/recent"
-    headers = {"Authorization": f"Bearer {token}"}
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
     params = {"query": symbol, "max_results": "50"}
-    async with session.get(url, headers=headers, params=params) as resp:
+    resp = await session.get(url, headers=headers, params=params)
+    async with resp:
         if resp.status != 200:
             return []
         data = await resp.json()
@@ -38,12 +37,13 @@ async def _fetch_tweets(pair: str, session: aiohttp.ClientSession) -> List[str]:
 async def _fetch_news(pair: str, session: aiohttp.ClientSession) -> List[dict]:
     """Fetch recent CryptoPanic news for the pair."""
     token = os.getenv("CRYPTOPANIC_TOKEN", "")
-    if not token:
-        return []
     symbol = pair.split("/")[0].lower()
     url = "https://cryptopanic.com/api/v1/posts/"
-    params = {"auth_token": token, "currencies": symbol}
-    async with session.get(url, params=params) as resp:
+    params = {"currencies": symbol}
+    if token:
+        params["auth_token"] = token
+    resp = await session.get(url, params=params)
+    async with resp:
         if resp.status != 200:
             return []
         data = await resp.json()

--- a/backend/graph/state.py
+++ b/backend/graph/state.py
@@ -1,8 +1,20 @@
-"""Graph state definitions."""
+"""State objects for the trading workflow."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import List, Optional
+
+import pandas as pd
+
+from .nodes.ingestion import Candle
+from .nodes.llm_scoring import SignalCandidate
 
 
 @dataclass
-class IndicatorBatch:
-    pass
+class TradingState:
+    """State passed between workflow nodes."""
+
+    candles: Optional[List[Candle]] = None
+    indicators_df: Optional[pd.DataFrame] = None
+    signals: Optional[List[SignalCandidate]] = None

--- a/backend/graph/workflow.py
+++ b/backend/graph/workflow.py
@@ -1,0 +1,67 @@
+"""LangGraph workflow for the trading research agent."""
+
+from __future__ import annotations
+
+import pandas as pd
+from backend.db.persistence import save_candles, save_indicators, save_signals
+from backend.graph.nodes.evaluation import evaluate_signals
+from backend.graph.nodes.indicators import compute_indicators
+from backend.graph.nodes.ingestion import PAIRS, fetch_candles
+from backend.graph.nodes.llm_scoring import score_signals
+from backend.graph.nodes.social import fetch_social_metrics
+from langgraph.graph import END, START, StateGraph
+
+from .state import TradingState
+
+
+async def ingest(_: TradingState) -> TradingState:
+    """Fetch candles and store them."""
+    candles = await fetch_candles(PAIRS)
+    if not candles:
+        return TradingState()
+    await save_candles(candles)
+    df = pd.DataFrame([c.__dict__ for c in candles])
+    return TradingState(candles=candles, indicators_df=df)
+
+
+async def compute(state: TradingState) -> TradingState:
+    """Compute indicators and persist them."""
+    if state.indicators_df is None:
+        return state
+    sentiment = await fetch_social_metrics(PAIRS)
+    indicators = compute_indicators(state.indicators_df, sentiment)
+    await save_indicators(indicators)
+    state.indicators_df = indicators
+    return state
+
+
+async def score(state: TradingState) -> TradingState:
+    """Score trading signals and persist the results."""
+    if state.indicators_df is None:
+        return state
+    signals = await score_signals(state.indicators_df)
+    await save_signals(signals)
+    state.signals = signals
+    return state
+
+
+async def evaluate(state: TradingState) -> TradingState:
+    """Evaluate previously generated signals."""
+    await evaluate_signals()
+    return state
+
+
+builder = StateGraph(TradingState)
+
+builder.add_node("ingest", ingest)
+builder.add_node("compute", compute)
+builder.add_node("score", score)
+builder.add_node("evaluate", evaluate)
+
+builder.add_edge(START, "ingest")
+builder.add_edge("ingest", "compute")
+builder.add_edge("compute", "score")
+builder.add_edge("score", "evaluate")
+builder.add_edge("evaluate", END)
+
+graph = builder.compile()

--- a/backend/langgraph.json
+++ b/backend/langgraph.json
@@ -1,7 +1,8 @@
 {
   "dependencies": ["."],
   "graphs": {
-    "agent": "./src/agent/graph.py:graph"
+    "agent": "./src/agent/graph.py:graph",
+    "trading": "./graph/workflow.py:graph"
   },
   "http": {
     "app": "./src/agent/app.py:app"


### PR DESCRIPTION
## Summary
- create `TradingState` dataclass for workflow state
- build new LangGraph graph in `workflow.py`
- fix social sentiment node to allow test mocking
- adjust llm scoring to fetch Qdrant client at call time
- register new graph in `langgraph.json`

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_683fcb3e14708320853e709bb754dbf7